### PR TITLE
Bump go from v1.5 to v1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5
+- 1.6
 install:
 - go get github.com/spf13/hugo
 script:


### PR DESCRIPTION
Upgrades golang from v1.5 to latest [v1.6](https://golang.org/doc/go1.6).

/cc @julia-allyce @freeeve 
